### PR TITLE
Statsd relay implementation.

### DIFF
--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -1,0 +1,203 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2017 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package statsd
+
+import (
+	"errors"
+	"net"
+	"strconv"
+	"strings"
+
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/intelsdi-x/snap-plugin-lib-go/v1/plugin"
+	"github.com/intelsdi-x/snap-relay/relay"
+)
+
+var (
+	ErrAlreadyStarted = errors.New("server already started")
+)
+
+type statsd struct {
+	udp       relay.Receiver
+	tcp       relay.Receiver
+	metrics   chan *plugin.Metric
+	done      chan struct{}
+	isStarted bool
+}
+
+func NewStatsd(opts ...option) *statsd {
+	statsd := &statsd{
+		udp:       relay.NewUDPListener(),
+		tcp:       relay.NewTCPListener(),
+		metrics:   make(chan *plugin.Metric, 1000),
+		done:      make(chan struct{}),
+		isStarted: false,
+	}
+
+	for _, opt := range opts {
+		opt(statsd)
+	}
+	return statsd
+}
+
+type option func(sd *statsd) option
+
+func UDPConnectionOption(conn *net.UDPConn) option {
+	return func(sd *statsd) option {
+		if sd.isStarted {
+			log.WithFields(log.Fields{
+				"_block": "UDPConnectionOption",
+			}).Warn("option cannot be set.  service already started")
+			return UDPConnectionOption(nil)
+		}
+		sd.udp = relay.NewUDPListener(relay.UDPConnectionOption(conn))
+		return UDPConnectionOption(conn)
+	}
+}
+
+func TCPListenerOption(conn *net.TCPListener) option {
+	return func(sd *statsd) option {
+		if sd.isStarted {
+			log.WithFields(log.Fields{
+				"_block": "TCPConnectionOption",
+			}).Warn("option cannot be set.  service already started")
+			return TCPListenerOption(nil)
+		}
+		sd.tcp = relay.NewTCPListener(relay.TCPListenerOption(conn))
+		return TCPListenerOption(conn)
+	}
+}
+
+func (sd *statsd) Start() error {
+	if sd.isStarted {
+		return ErrAlreadyStarted
+	}
+	sd.udp.Start()
+	sd.tcp.Start()
+	sd.isStarted = true
+	go func() {
+		for {
+			select {
+			case data := <-sd.udp.Data():
+				lines := strings.Split(string(data), "\n")
+				for _, line := range lines {
+					if metric := parseData(string(line)); metric != nil {
+						select {
+						case sd.metrics <- metric:
+						default:
+							log.WithFields(log.Fields{
+								"transport":        "udp",
+								"_block":           "statsd",
+								"metric_namespace": strings.Join(metric.Namespace.Strings(), "/"),
+							}).Warn("dropping metric.  Channel is full")
+						}
+					}
+				}
+			case data := <-sd.tcp.Data():
+				lines := strings.Split(string(data), "\n")
+				for _, line := range lines {
+					if metric := parseData(string(line)); metric != nil {
+						select {
+						case sd.metrics <- metric:
+						default:
+							log.WithFields(log.Fields{
+								"transport":        "tcp",
+								"_block":           "statsd",
+								"metric_namespace": strings.Join(metric.Namespace.Strings(), "/"),
+							}).Warn("dropping metric.  Channel is full")
+						}
+					}
+				}
+			case <-sd.done:
+				break
+			}
+		}
+	}()
+	return nil
+}
+
+func (sd *statsd) Metrics() chan *plugin.Metric {
+	return sd.metrics
+}
+
+func (sd *statsd) stop() {
+	sd.udp.Stop()
+	sd.tcp.Stop()
+	close(sd.done)
+}
+
+func parseMetricType(t string) string {
+	switch t {
+	case "c":
+		return "counter"
+	case "g":
+		return "gauge"
+	case "s":
+		return "set"
+	case "ms":
+		return "timer"
+	default:
+		return t
+	}
+
+}
+
+func parseData(data string) *plugin.Metric {
+	tags := map[string]string{}
+	lineElems := strings.Split(data, "|")
+	if len(lineElems) >= 2 {
+		log.WithFields(log.Fields{
+			"_block":        "parseData",
+			"received_data": data,
+			"expected_data": "<metric>:<value>|<type>",
+		}).Error("invalid metric line")
+		return nil
+	}
+	tags["data_type"] = parseMetricType(lineElems[1])
+	metricElements := strings.Split(lineElems[0], ":")
+	if len(metricElements) != 2 {
+		log.WithFields(log.Fields{
+			"_block":        "parseData",
+			"received_data": lineElems[0],
+			"expected_data": "<metric>:<value>",
+		}).Error("invalid data in metric line")
+		return nil
+	}
+	ns := plugin.NewNamespace("statsd")
+	ns = ns.AddStaticElements(strings.Split(metricElements[0], ".")...)
+	value, err := strconv.ParseInt(metricElements[1], 10, 64)
+
+	if err != nil {
+		log.WithFields(log.Fields{
+			"_block":    "parseData",
+			"namespace": ns,
+			"data":      value,
+			"error":     err.Error(),
+		}).Error("failed to parse data")
+		return nil
+	}
+	return &plugin.Metric{
+		Namespace: ns,
+		Data:      value,
+		Tags:      tags,
+		Timestamp: time.Now(),
+	}
+}

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -1,0 +1,100 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2017 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package statsd
+
+import (
+	"net"
+	"testing"
+
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestStatsd(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+	Convey("Setup statsd server", t, func() {
+		udpAddr, err := net.ResolveUDPAddr("udp", "localhost:0")
+		So(err, ShouldBeNil)
+		So(udpAddr, ShouldNotBeNil)
+		udpConn, err := net.ListenUDP("udp", udpAddr)
+		So(err, ShouldBeNil)
+		So(udpConn, ShouldNotBeNil)
+		tcpAddr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+		So(err, ShouldBeNil)
+		So(tcpAddr, ShouldNotBeNil)
+		listen, err := net.ListenTCP("tcp", tcpAddr)
+		So(err, ShouldBeNil)
+		statsd := NewStatsd(UDPConnectionOption(udpConn), TCPListenerOption(listen))
+		So(statsd, ShouldNotBeNil)
+		err = statsd.Start()
+		So(err, ShouldBeNil)
+		// create tcpClient
+		tcpAddr, err = net.ResolveTCPAddr("tcp", listen.Addr().String())
+		So(err, ShouldBeNil)
+		So(tcpAddr, ShouldNotBeNil)
+		tcpClient, err := net.DialTCP("tcp", nil, tcpAddr)
+		Convey("starts already started server", func() {
+			err = statsd.Start()
+			So(err, ShouldNotBeNil)
+			So(err, ShouldResemble, ErrAlreadyStarted)
+		})
+		Convey("receives invalid data over UDP", func() {
+			msgs := []string{"hello\n", "foo\n", "bar\n"}
+			for _, msg := range msgs {
+				_, err := udpConn.WriteTo([]byte(msg), udpConn.LocalAddr())
+				So(err, ShouldBeNil)
+			}
+			time.Sleep(100 * time.Millisecond)
+			So(len(statsd.metrics), ShouldEqual, 0)
+		})
+		Convey("receives invalid data over TCP", func() {
+			msgs := []string{"hello\n", "foo\n", "bar\n"}
+			for _, msg := range msgs {
+				_, err := tcpClient.Write([]byte(msg))
+				So(err, ShouldBeNil)
+			}
+			time.Sleep(100 * time.Millisecond)
+			So(len(statsd.metrics), ShouldEqual, 0)
+		})
+		Convey("sends valid UDP data", func() {
+			msgs := []string{
+				"foo.bar:7|c\n",
+				"foo.bar:8|g\n",
+				"foo.bar:97|s\n",
+			}
+			for _, msg := range msgs {
+				_, err := udpConn.WriteTo([]byte(msg), udpConn.LocalAddr())
+				So(err, ShouldBeNil)
+			}
+			time.Sleep(100 * time.Millisecond)
+			So(len(statsd.metrics), ShouldEqual, 3)
+			Convey("sends valid TCP data", func() {
+				for _, msg := range msgs {
+					_, err := tcpClient.Write([]byte(msg))
+					So(err, ShouldBeNil)
+				}
+				time.Sleep(100 * time.Millisecond)
+				So(len(statsd.metrics), ShouldEqual, 6)
+			})
+		})
+	})
+
+}


### PR DESCRIPTION
Converts statsd format data (metricname:value|type) to snap metric schema.
- metricname is parsed to namespace
- value is parsed as data
- type is placed to tags as "data_type"

Signed-off-by: Patryk Matyjasek <patryk.matyjasek@intel.com>