### PR TITLE
Add statsd implementation

### DIFF
--- a/graphite/graphite.go
+++ b/graphite/graphite.go
@@ -84,6 +84,10 @@ func NewGraphite(opts ...Option) *graphite {
 
 type Option func(g *graphite) Option
 
+func (o Option) Type() string {
+	return "graphite"
+}
+
 // Metrics is provided a context used for communicating cancellation.
 func (g *graphite) Metrics(ctx context.Context) chan *plugin.Metric {
 	mchan := make(chan *plugin.Metric, 1000)

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -60,6 +60,10 @@ func NewStatsd(opts ...Option) *statsd {
 
 type Option func(sd *statsd) Option
 
+func (o Option) Type() string {
+	return "statsd"
+}
+
 func UDPConnectionOption(conn *net.UDPConn) Option {
 	return func(sd *statsd) Option {
 		if sd.isStarted {


### PR DESCRIPTION
- Added statsd implementation to snap-relay plugin. 
- Changed namespace from relay to protocol in statsd package. 
- Exported Option

Known issue: currently line 65 of relay.go doesn't work (it is commented out). The error is related to `context`, See below: 
```
relay/relay.go:65: cannot use statsd.NewStatsd(sOpts...) (type *statsd.statsd) as type relayMetrics in field value:
	*statsd.statsd does not implement relayMetrics (wrong type for Metrics method)
		have Metrics() chan *plugin.Metric
		want Metrics("context".Context) chan *plugin.Metric
```