### PR TITLE
Updated location of task in docker-compose.yml

### DIFF
--- a/examples/docker-example/README.md
+++ b/examples/docker-example/README.md
@@ -1,8 +1,3 @@
-### Disclaimer: 
-The location in docker-compose.yml for getting the task manifest publishInfluxdb.yml (line 76) will need to be updated after PR is merged. This is because the location of the docker-compose should no longer point to my branch (github.com/kjlyon/snap-relay/tree/update-readme/examples/docker-example/publishInfluxdb.yml) but should point to the permenant location of that file in intelsdi-x/snap-relay/examples/docker-example/publishInfluxdb.yml. 
-
-
-
 # Running an example in docker-compose
 
 ## Requirements 

--- a/examples/docker-example/docker-compose.yml
+++ b/examples/docker-example/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       - "apk add --update curl; \
          curl -i -XPOST http://influxdb:8086/query --data-urlencode \"q=CREATE DATABASE snap\"; \
          curl -o /tmp/snap-plugin-publisher-influxdb http://snap.ci.snap-telemetry.io/plugins/snap-plugin-publisher-influxdb/latest/linux/x86_64/snap-plugin-publisher-influxdb; \
-         curl -o /tmp/publishInfluxdb.yml https://github.com/kjlyon/snap-relay/tree/update-readme/examples/docker-example/publishInfluxdb.yml; \
+         curl -o /tmp/publishInfluxdb.yml https://github.com/intelsdi-x/snap-relay/blob/master/examples/docker-example/publishInfluxdb.yml; \
          snaptel -u http://snap:8181 plugin load /tmp/snap-plugin-publisher-influxdb; \
          snaptel -u http://snap:8181 plugin load http://relay:8182; \
          snaptel -u http://snap:8181 task create -t original.yml"


### PR DESCRIPTION
Removes [disclaimer](https://github.com/intelsdi-x/snap-relay/tree/master/examples/docker-example#disclaimer) from #6 

Removed disclaimer message
Updated address of link to task manifest in docker-compose.yml