### PR TITLE
Fetch taskID from metadata and correlate to log messages

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -69,7 +69,8 @@ func main() {
 		},
 	}
 
-	metricsOut, errOut, err := c.StreamMetrics(requested_metrics)
+	metricsOut, errOut, err := c.StreamMetrics("test-TaskID", requested_metrics)
+
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Summary:

- Get taskID using context and use it for correlation of taskID to data and metric in debug log messages.