### PR TITLE
Add small tests

### DIFF
--- a/protocol/udp_test.go
+++ b/protocol/udp_test.go
@@ -54,6 +54,7 @@ func TestUDPListen(t *testing.T) {
 				}
 			}
 			So(len(server.data), ShouldEqual, 0)
+			So(len(server.Data()), ShouldEqual, 0)
 
 			Convey("without newline", func() {
 				msgs := []string{"hello", "foo", "bar"}
@@ -76,6 +77,28 @@ func TestUDPListen(t *testing.T) {
 		case <-time.After(100 * time.Millisecond):
 			t.Error("Timed out waiting for UDP server to stop")
 		}
+	})
+
+	Convey("Setup failing UDP server", t, func(c C) {
+		//good ResolveUDPAddr
+		udpAddr, err := net.ResolveUDPAddr("udp", "localhost:0")
+		So(err, ShouldBeNil)
+		So(udpAddr, ShouldNotBeNil)
+
+		//bad server.Start
+		BadConn, err := net.ListenUDP("udppdu", udpAddr)
+		So(err, ShouldNotBeNil)
+
+		//start server with badConn
+		listenPort := 5
+		server := NewUDPListener(UDPConnectionOption(BadConn), UDPListenPortOption(&listenPort))
+		err = server.Start()
+		c.So(err, ShouldNotBeNil)
+
+		//start server with no conn
+		server = NewUDPListener()
+		err = server.Start()
+		c.So(err, ShouldBeNil)
 	})
 
 }

--- a/relay/relay_test.go
+++ b/relay/relay_test.go
@@ -21,8 +21,11 @@ limitations under the License.
 package relay
 
 import (
+	"net"
 	"testing"
 
+	"github.com/intelsdi-x/snap-relay/graphite"
+	"github.com/intelsdi-x/snap-relay/statsd"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -42,6 +45,22 @@ func TestRelay(t *testing.T) {
 		Convey("No error returned", func() {
 			So(err, ShouldBeNil)
 		})
+	})
+
+	Convey("Test New", t, func() {
+		udpAddr, err := net.ResolveUDPAddr("udp", "localhost:0")
+		So(err, ShouldBeNil)
+		So(udpAddr, ShouldNotBeNil)
+		udpConn, err := net.ListenUDP("udp", udpAddr)
+		So(err, ShouldBeNil)
+		So(udpConn, ShouldNotBeNil)
+		//create graphite option for test
+		myGraphiteUDPOption := graphite.UDPConnectionOption(udpConn)
+		//create statsd option for test
+		myStatsdUDPOption := statsd.UDPConnectionOption(udpConn)
+
+		newRelayTCP := New(myGraphiteUDPOption, myStatsdUDPOption)
+		So(newRelayTCP, ShouldNotBeNil)
 	})
 
 	// Test for StreamMetrics can be found in client/client_test.go as a medium test


### PR DESCRIPTION
Added small tests to: 
- graphite_test
- tcp_test.go
- udp_test.go
- relay_test.go
- statsd_test.go

New test coverage: 
```
github.com/intelsdi-x/snap-relay/graphite/graphite.go:69:	NewGraphite		100.0%
github.com/intelsdi-x/snap-relay/graphite/graphite.go:87:	Type			100.0%
github.com/intelsdi-x/snap-relay/graphite/graphite.go:92:	Metrics			83.3%
github.com/intelsdi-x/snap-relay/graphite/graphite.go:104:	UDPConnectionOption	100.0%
github.com/intelsdi-x/snap-relay/graphite/graphite.go:117:	UDPListenPortOption	100.0%
github.com/intelsdi-x/snap-relay/graphite/graphite.go:131:	TCPListenPortOption	100.0%
github.com/intelsdi-x/snap-relay/graphite/graphite.go:145:	TCPListenerOption	100.0%
github.com/intelsdi-x/snap-relay/graphite/graphite.go:158:	Start			84.0%
github.com/intelsdi-x/snap-relay/graphite/graphite.go:217:	stop			100.0%
github.com/intelsdi-x/snap-relay/graphite/graphite.go:223:	parse			84.6%
github.com/intelsdi-x/snap-relay/protocol/tcp.go:44:		NewTCPListener		100.0%
github.com/intelsdi-x/snap-relay/protocol/tcp.go:55:		TCPListenerOption	100.0%
github.com/intelsdi-x/snap-relay/protocol/tcp.go:63:		TCPListenPortOption	100.0%
github.com/intelsdi-x/snap-relay/protocol/tcp.go:71:		Data			100.0%
github.com/intelsdi-x/snap-relay/protocol/tcp.go:75:		Stop			100.0%
github.com/intelsdi-x/snap-relay/protocol/tcp.go:79:		listen			91.7%
github.com/intelsdi-x/snap-relay/protocol/tcp.go:102:		handleConn		66.7%
github.com/intelsdi-x/snap-relay/protocol/tcp.go:149:		Start			58.8%
github.com/intelsdi-x/snap-relay/protocol/udp.go:39:		NewUDPListener		100.0%
github.com/intelsdi-x/snap-relay/protocol/udp.go:52:		UDPConnectionOption	100.0%
github.com/intelsdi-x/snap-relay/protocol/udp.go:60:		UDPListenPortOption	100.0%
github.com/intelsdi-x/snap-relay/protocol/udp.go:68:		listen			91.7%
github.com/intelsdi-x/snap-relay/protocol/udp.go:92:		Data			100.0%
github.com/intelsdi-x/snap-relay/protocol/udp.go:96:		Stop			100.0%
github.com/intelsdi-x/snap-relay/protocol/udp.go:100:		Start			72.4%
github.com/intelsdi-x/snap-relay/relay/relay.go:53:		New			100.0%
github.com/intelsdi-x/snap-relay/relay/relay.go:72:		StreamMetrics		0.0%
github.com/intelsdi-x/snap-relay/relay/relay.go:132:		dispatchMetrics		0.0%
github.com/intelsdi-x/snap-relay/relay/relay.go:159:		GetMetricTypes		100.0%
github.com/intelsdi-x/snap-relay/relay/relay.go:174:		GetConfigPolicy		100.0%
github.com/intelsdi-x/snap-relay/statsd/statsd.go:68:		NewStatsd		100.0%
github.com/intelsdi-x/snap-relay/statsd/statsd.go:86:		Type			100.0%
github.com/intelsdi-x/snap-relay/statsd/statsd.go:90:		UDPConnectionOption	100.0%
github.com/intelsdi-x/snap-relay/statsd/statsd.go:103:		UDPListenPortOption	100.0%
github.com/intelsdi-x/snap-relay/statsd/statsd.go:117:		TCPListenPortOption	100.0%
github.com/intelsdi-x/snap-relay/statsd/statsd.go:131:		TCPListenerOption	100.0%
github.com/intelsdi-x/snap-relay/statsd/statsd.go:144:		Start			86.2%
github.com/intelsdi-x/snap-relay/statsd/statsd.go:210:		Metrics			83.3%
github.com/intelsdi-x/snap-relay/statsd/statsd.go:222:		stop			100.0%
github.com/intelsdi-x/snap-relay/statsd/statsd.go:228:		parseMetricType		66.7%
github.com/intelsdi-x/snap-relay/statsd/statsd.go:244:		parseData		77.8%
total:								(statements)		77.1%
```
